### PR TITLE
Match backend subscription status values in getSubscriptionStatus

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -420,7 +420,8 @@ const api = {
                 let currentPlan: "free" | "standard" | "lifetime";
                 
                 switch (subscription.status) {
-                    case "active":
+                    case "standard":
+                    case "past_due":
                         status = "standard";
                         currentPlan = "standard";
                         break;
@@ -428,9 +429,9 @@ const api = {
                         status = "lifetime";
                         currentPlan = "lifetime";
                         break;
-                    case "cancelled":
+                    case "canceled":
                         status = "cancelled";
-                        currentPlan = "standard"; // Assume they had standard before cancelling
+                        currentPlan = "free";
                         break;
                     default:
                         status = "free";


### PR DESCRIPTION
## Summary
- `getSubscriptionStatus()` was switching on Stripe's raw status values (`"active"`, `"cancelled"`), but the backend maps those to the app enum (`"free" | "standard" | "lifetime" | "canceled" | "past_due"`) in `mapStripeStatus()` before writing to the DB. `"standard"` fell through to `default` and the UI showed paid users as free.
- Switch now matches the actual values the backend returns. `"canceled"` (single-l, matching Stripe/DB) replaces the dead `"cancelled"` case; `"past_due"` is treated as standard (grace period); cancelled users drop back to the free plan.

## Test plan
- [ ] Paid user with `leetrepeat_subscriptions.status = 'standard'` sees the standard plan in Account Settings and no upgrade CTA on the homepage
- [ ] Free user still sees the free plan + upgrade CTA
- [ ] Canceled user is shown as free (no longer displayed as "standard" post-cancel)

https://claude.ai/code/session_01L9gEWgjGzin6j3ZtppzEHZ