### PR TITLE
Remove /auth/graphql endpoint from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ The components automatically connect to the auth service running on your domain 
 - `GET /auth/session` - Session validation
 - `GET /auth/csrf-token` - CSRF token generation
 - `GET /auth/health` - Service health check
-- `POST /auth/graphql` - GraphQL endpoint for data operations
 
 ### CSRF Protection
 


### PR DESCRIPTION
## Summary
- Part of the GraphQL deprecation across the platform (consumers have migrated to tRPC).
- Removes the stale `POST /auth/graphql` bullet from the auth service endpoint list.

## Test plan
- [ ] Docs render cleanly; no remaining `graphql` references in `README.md`.