### PR TITLE
fix: enable mock auth on Cloudflare Pages preview deployments

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -315,13 +315,20 @@ class AuthClient {
   }
 
   /**
-   * Check if we should use mock mode
+   * Check if we should use mock mode.
+   *
+   * Mock mode is active when running on localhost (any build mode) or on a
+   * Cloudflare Pages preview URL (*.pages.dev). Preview deployments are
+   * production builds so import.meta.env.DEV is false there — the old check
+   * `this.isDevelopment && localhost` never activated, causing the app to
+   * call the real auth service which rejects *.pages.dev origins via CORS.
    */
   private shouldUseMock(): boolean {
-    // In development, use mock mode if we're on localhost
-    return this.isDevelopment && (
-      window.location.hostname.includes('localhost') ||
-      window.location.hostname.includes('127.0.0.1')
+    const hostname = window.location.hostname;
+    return (
+      hostname.includes('localhost') ||
+      hostname.includes('127.0.0.1') ||
+      hostname.endsWith('.pages.dev')
     );
   }
 
@@ -712,4 +719,4 @@ class AuthClient {
 export const auth = new AuthClient();
 
 // Re-export types for convenience
-export type { User, Session, AuthResponse, LoginData, SignupData }; 
+export type { User, Session, AuthResponse, LoginData, SignupData };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -318,9 +318,9 @@ class AuthClient {
    * Check if we should use mock mode.
    *
    * Active on localhost (any build mode) and on Cloudflare Pages *preview*
-   * deployments. Preview URLs have an extra subdomain prefix:
-   *   <hash>.<project>.pages.dev  →  4+ hostname segments  (preview → mock)
-   *   <project>.pages.dev         →  3 hostname segments   (production → real auth)
+   * deployments. Cloudflare Pages URL structure:
+   *   <hash-or-branch>.<project>.pages.dev  →  4+ segments  (preview → mock)
+   *   <project>.pages.dev                   →  3 segments   (production → real auth)
    *
    * The previous check gated on `this.isDevelopment` (import.meta.env.DEV),
    * which is false on Cloudflare Pages (production build). That meant every
@@ -330,7 +330,7 @@ class AuthClient {
     if (typeof window === 'undefined') return false;
     const hostname = window.location.hostname;
 
-    if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
+    if (hostname === 'localhost' || hostname === '127.0.0.1') {
       return true;
     }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -317,20 +317,31 @@ class AuthClient {
   /**
    * Check if we should use mock mode.
    *
-   * Mock mode is active when running on localhost (any build mode) or on a
-   * Cloudflare Pages preview URL (*.pages.dev). Preview deployments are
-   * production builds so import.meta.env.DEV is false there — the old check
-   * `this.isDevelopment && localhost` never activated, causing the app to
-   * call the real auth service which rejects *.pages.dev origins via CORS.
+   * Active on localhost (any build mode) and on Cloudflare Pages *preview*
+   * deployments. Preview URLs have an extra subdomain prefix:
+   *   <hash>.<project>.pages.dev  →  4+ hostname segments  (preview → mock)
+   *   <project>.pages.dev         →  3 hostname segments   (production → real auth)
+   *
+   * The previous check gated on `this.isDevelopment` (import.meta.env.DEV),
+   * which is false on Cloudflare Pages (production build). That meant every
+   * preview tried the real auth service and was blocked by CORS.
    */
   private shouldUseMock(): boolean {
     if (typeof window === 'undefined') return false;
     const hostname = window.location.hostname;
-    return (
-      hostname.includes('localhost') ||
-      hostname.includes('127.0.0.1') ||
-      hostname.endsWith('.pages.dev')
-    );
+
+    if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
+      return true;
+    }
+
+    // Cloudflare Pages preview URLs: <hash-or-branch>.<project>.pages.dev
+    // Production Pages URLs:          <project>.pages.dev
+    // Distinguish by segment count: previews have 4+, production has 3.
+    if (hostname.endsWith('.pages.dev')) {
+      return hostname.split('.').length >= 4;
+    }
+
+    return false;
   }
 
   /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -324,6 +324,7 @@ class AuthClient {
    * call the real auth service which rejects *.pages.dev origins via CORS.
    */
   private shouldUseMock(): boolean {
+    if (typeof window === 'undefined') return false;
     const hostname = window.location.hostname;
     return (
       hostname.includes('localhost') ||


### PR DESCRIPTION
## Problem

Cloudflare Pages preview deployments (PR previews) were stuck at the landing page — you could see the UI but couldn't log in or register.

**Root cause** — `shouldUseMock()` in `src/lib/auth.ts`:

```typescript
// Before
private shouldUseMock(): boolean {
  return this.isDevelopment && (   // ← false on CF Pages (production build)
    window.location.hostname.includes('localhost') ||
    window.location.hostname.includes('127.0.0.1')
  );
}
```

Cloudflare Pages builds with `NODE_ENV=production`, so `import.meta.env.DEV` is `false`. Mock mode never activated. The app then called the real auth service, which rejected the request on two fronts:
1. **CORS** — only `leetrepeat.com` / `stage.leetrepeat.com` are in the domain allowlist; preview URLs are blocked
2. **Routing** — `routing.ts` can't map a preview hostname to a valid project/worker binding

Result: every auth call failed silently, leaving the user stuck on the landing page.

## Fix

Replace the `isDevelopment` gate with explicit hostname checks:

```typescript
// After
private shouldUseMock(): boolean {
  if (typeof window === 'undefined') return false;
  const hostname = window.location.hostname;

  if (hostname === 'localhost' || hostname === '127.0.0.1') {
    return true;
  }

  // Cloudflare Pages preview URLs: <hash-or-branch>.<project>.pages.dev  → 4+ segments
  // Cloudflare Pages production URLs:          <project>.pages.dev        → 3 segments
  if (hostname.endsWith('.pages.dev')) {
    return hostname.split('.').length >= 4;
  }

  return false;
}
```

Hostname → behaviour mapping:

| Hostname | Segments | Mock? |
|---|---|---|
| `localhost` / `127.0.0.1` | — | ✅ yes |
| `abc123.leetrepeat.pages.dev` | 4 | ✅ yes (PR preview) |
| `leetrepeat.pages.dev` | 3 | ❌ no (production Pages) |
| `leetrepeat.com` | 2 | ❌ no (production custom domain) |
| `stage.leetrepeat.com` | 3 | ❌ no (staging custom domain) |

## Test plan

- [ ] Open a PR preview URL (e.g. `https://abc123.leetrepeat.pages.dev`)
- [ ] Click "Sign In" or "Get Started" on the landing page
- [ ] Complete the login/register flow with any email + password
- [ ] Confirm you land on the dashboard and can interact with the app
- [ ] Verify `leetrepeat.com` and `stage.leetrepeat.com` still use real auth (no regression)
- [ ] Verify `leetrepeat.pages.dev` (if it exists) still uses real auth