### PR TITLE
Fix Google SSO JSON parse error

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -320,7 +320,7 @@ const api = {
         const response = await fetch(`${getApiUrl()}/auth/oauth/initiate?provider=${provider}&staySignedIn=${staySignedIn}&frontendRedirectUrl=${encodeURIComponent(frontendRedirectUrl)}`, {
             method: 'GET',
             headers: {
-                'Content-Type': 'application/json',
+                'Accept': 'application/json',
             },
         });
 
@@ -328,7 +328,21 @@ const api = {
             throw new Error(`Failed to initiate OAuth: ${response.status} ${response.statusText}`);
         }
 
-        return await response.json();
+        // Read as text first so a non-JSON body (e.g. plain "OK") produces a
+        // clear error instead of a cryptic "Unexpected token 'O'" SyntaxError.
+        const body = await response.text();
+        let data: { url?: string };
+        try {
+            data = JSON.parse(body);
+        } catch {
+            throw new Error(`OAuth initiate returned a non-JSON response: "${body.slice(0, 100)}"`);
+        }
+
+        if (!data.url) {
+            throw new Error('OAuth initiate response missing redirect url');
+        }
+
+        return { url: data.url };
     },
 
     // Stripe API calls


### PR DESCRIPTION
## Summary

Clicking "Sign in with Google" surfaced a cryptic error:

> Unexpected token 'O', "OK" is not valid JSON

This came from `api.initiateOAuth` in `src/lib/api.ts`, which unconditionally called `response.json()` on the `/auth/oauth/initiate` response. When the backend returned a plain `OK` body (or anything non-JSON), the raw `SyntaxError` bubbled all the way up to the `OAuthButtons` error handler and was shown to the user.

### Changes

- Read the body as text first and `JSON.parse` it inside a try/catch so a non-JSON payload produces a clear, actionable error (`OAuth initiate returned a non-JSON response: "OK"`) instead of the cryptic SyntaxError.
- Validate that the parsed response actually contains the expected `url` field; error explicitly if it does not.
- Swap the request header from `Content-Type: application/json` (wrong for a GET with no body) to `Accept: application/json` so any server doing content negotiation returns JSON.

### Test plan

- [ ] Click "Sign in with Google" in a preview/production build and confirm redirect to Google proceeds (assuming the backend returns `{ url }`).
- [ ] If the backend happens to return a non-JSON body, confirm the surfaced error reads like `OAuth initiate returned a non-JSON response: "..."` instead of the old `Unexpected token 'O'` message.
- [ ] Mock mode on localhost still bypasses the real OAuth call and signs in with the mock user.