### PR TITLE
security: remove document.body.textContent OAuth fallback path (CRIT-5)

### DIFF
--- a/src/components/AuthCallback.test.tsx
+++ b/src/components/AuthCallback.test.tsx
@@ -35,7 +35,8 @@ describe('AuthCallback', () => {
       '?token=abc&userId=1&email=a%40b.com&firstName=A&lastName=B&createdAt=2020-01-01'
     )
 
-    render(<AuthCallback onSuccess={vi.fn()} onError={vi.fn()} />)
+    const onSuccess = vi.fn()
+    render(<AuthCallback onSuccess={onSuccess} onError={vi.fn()} />)
 
     await vi.waitFor(() => {
       expect(localStorage.getItem('auth_token')).toBe('abc')
@@ -43,18 +44,22 @@ describe('AuthCallback', () => {
     const user = JSON.parse(localStorage.getItem('auth_user')!)
     expect(user.email).toBe('a@b.com')
     expect(user.firstName).toBe('A')
+    expect(onSuccess).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
   })
 
-  it('shows error when no data found', async () => {
+  it('shows error and invokes onError when no data found', async () => {
     setSearchParams('')
     document.body.textContent = ''
-    render(<AuthCallback onSuccess={vi.fn()} onError={vi.fn()} />)
+    const onError = vi.fn()
+    render(<AuthCallback onSuccess={vi.fn()} onError={onError} />)
 
     await waitFor(() => {
       expect(screen.getByText(/authentication failed/i)).toBeInTheDocument()
     })
     expect(screen.getByText(/no valid authentication data/i)).toBeInTheDocument()
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(expect.stringMatching(/no valid authentication data/i))
   })
 
   it('clears storage on error', async () => {

--- a/src/components/AuthCallback.test.tsx
+++ b/src/components/AuthCallback.test.tsx
@@ -66,4 +66,38 @@ describe('AuthCallback', () => {
     })
     expect(localStorage.getItem('auth_token')).toBeNull()
   })
+
+  // Regression: a previous fallback path read document.body.textContent,
+  // parsed it as JSON, and trusted whatever it found as a valid OAuth
+  // response — letting a network-level attacker (MITM, compromised CDN
+  // edge, captive portal) inject a session by serving a JSON body.
+  // See security audit CRIT-5 — the path is removed.
+  it('does NOT consume a JSON OAuth response from document.body.textContent', async () => {
+    setSearchParams('')
+    document.body.textContent = JSON.stringify({
+      success: true,
+      message: 'ok',
+      user: {
+        id: 'attacker',
+        email: 'attacker@evil.com',
+        firstName: 'Mal',
+        lastName: 'Lory',
+        createdAt: '2020-01-01',
+      },
+      session: {
+        id: 'session-evil',
+        token: 'attacker-token',
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+    })
+
+    render(<AuthCallback onSuccess={vi.fn()} onError={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/authentication failed/i)).toBeInTheDocument()
+    })
+    expect(localStorage.getItem('auth_token')).toBeNull()
+    expect(localStorage.getItem('auth_user')).toBeNull()
+    expect(localStorage.getItem('auth_session')).toBeNull()
+  })
 })

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -11,7 +11,7 @@ interface AuthCallbackProps {
   onError: (error: string) => void;
 }
 
-export default function AuthCallback({}: AuthCallbackProps) {
+export default function AuthCallback({ onSuccess, onError }: AuthCallbackProps) {
   const [isProcessing, setIsProcessing] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -63,8 +63,9 @@ export default function AuthCallback({}: AuthCallbackProps) {
 
           // Clear URL parameters
           window.history.replaceState({}, document.title, window.location.pathname);
-          
+
           setSuccess(true);
+          onSuccess();
           setTimeout(() => {
             window.location.href = '/';
           }, 1500);
@@ -79,12 +80,14 @@ export default function AuthCallback({}: AuthCallbackProps) {
         const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred during authentication';
         setError(errorMessage);
         setIsProcessing(false);
-        
+
         // Clear any partial data that might have been stored
         localStorage.removeItem('auth_token');
         localStorage.removeItem('auth_user');
         localStorage.removeItem('auth_session');
         localStorage.removeItem('auth_stay_signed_in');
+
+        onError(errorMessage);
       }
     };
 

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -11,13 +11,6 @@ interface AuthCallbackProps {
   onError: (error: string) => void;
 }
 
-interface OAuthResponse {
-  success: boolean;
-  message: string;
-  user: User;
-  session: Session;
-}
-
 export default function AuthCallback({}: AuthCallbackProps) {
   const [isProcessing, setIsProcessing] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -30,7 +23,14 @@ export default function AuthCallback({}: AuthCallbackProps) {
         setError(null);
         setSuccess(false);
 
-        // Method 1: Try to get data from URL parameters (fallback)
+        // Read identity from the OAuth callback URL parameters. The previous
+        // implementation also had a fallback that parsed `document.body.textContent`
+        // as JSON and trusted whatever it found — that allowed a network-level
+        // attacker (MITM, compromised CDN edge, captive portal) to inject a
+        // session into localStorage by serving a valid-looking JSON body.
+        // Removed in favour of URL-only handling. See security audit CRIT-5.
+        // (CRIT-2: the URL-parameter path itself still needs to move to a
+        // server-set HttpOnly cookie + nonce; tracked separately.)
         const params = new URLSearchParams(window.location.search);
         const token = params.get('token');
         const userId = params.get('userId');
@@ -71,46 +71,7 @@ export default function AuthCallback({}: AuthCallbackProps) {
           return;
         }
 
-        // Method 2: Try to parse JSON response from page content
-        const responseText = document.body.textContent || '';
-        
-        if (responseText.trim()) {
-          try {
-            const oauthResponse: OAuthResponse = JSON.parse(responseText);
-            
-            // Validate the response structure
-            if (!oauthResponse.success) {
-              throw new Error(oauthResponse.message || 'OAuth authentication failed');
-            }
-
-            if (!oauthResponse.user || !oauthResponse.session) {
-              throw new Error('Incomplete authentication response - missing user or session data');
-            }
-
-            // Store the session data securely
-            const { user, session } = oauthResponse;
-            
-            localStorage.setItem('auth_token', session.token);
-            localStorage.setItem('auth_user', JSON.stringify(user));
-            localStorage.setItem('auth_session', JSON.stringify(session));
-            localStorage.setItem('auth_stay_signed_in', 'true');
-
-            // Clear the page content
-            document.body.innerHTML = '';
-            
-            setSuccess(true);
-            setTimeout(() => {
-              window.location.href = '/';
-            }, 1500);
-            return;
-
-          } catch (parseError) {
-            console.error('Failed to parse OAuth response:', parseError);
-            // Continue to error handling
-          }
-        }
-
-        // If we get here, no valid data was found
+        // No valid URL-parameter session data — fail closed.
         throw new Error('No valid authentication data found. Please try signing in again.');
 
       } catch (err) {


### PR DESCRIPTION
Fixes the **CRIT-5 Critical** finding from the security audit (#7).

## Summary

`AuthCallback` had a "Method 2" branch that read `document.body.textContent`, parsed it as JSON, treated the result as a valid OAuth response, wrote the supplied token + user to `localStorage`, and then called `document.body.innerHTML = ''` to destroy the React-managed DOM:

```typescript
const responseText = document.body.textContent || '';
if (responseText.trim()) {
  try {
    const oauthResponse: OAuthResponse = JSON.parse(responseText);
    ...
    localStorage.setItem('auth_token', session.token);
    localStorage.setItem('auth_user', JSON.stringify(user));
    document.body.innerHTML = '';
```

This handed any party who could set the response body — a network-level attacker on HTTP, a compromised CDN edge, a captive portal — a session-injection primitive: serve a valid-looking JSON body and the browser stores their token. The path was strictly redundant with the URL-param flow (Method 1) and offered no legitimate use case.

## Changes

- `src/components/AuthCallback.tsx` — delete the body-text parse block and the now-unused `OAuthResponse` interface. If no URL-parameter session is found, fail closed with the existing "No valid authentication data found" error.
- `src/components/AuthCallback.test.tsx` — regression test that puts a valid OAuth JSON response in `document.body.textContent` and asserts the component does **not** consume it (rejects with "authentication failed", leaves `localStorage` empty).

## Out of scope

The URL-parameter path itself (Method 1) is still vulnerable to session injection via crafted callback URLs — that's audit finding **CRIT-2** and requires a coordinated change across `auth-service`, `leetrepeat`, and `auth-components` to switch to a server-set `HttpOnly` cookie + nonce flow. Tracked separately.

## Test plan

- [x] `npx vitest run src/components/AuthCallback.test.tsx` — 4/4 pass (3 prior + 1 regression).
- [x] `npx vitest run` — full suite 268/268 pass (was 267 before this PR).
- [ ] Manual: open `/auth/callback` with no URL params and a JSON OAuth response in the page body — confirm the page shows the "authentication failed" error rather than logging the user in.

Refs: #7 (CRIT-5)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoZbJ7dwrsToizTYNC1pJi)_