### PR TITLE
ci: cancel superseded runs and skip docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

Reduce GitHub Actions usage on this repo:

- **Concurrency cancel-in-progress** so rapid PR pushes don't keep an old run going.
- **Skip CI on docs-only changes** (`**/*.md`, `docs/**`, issue templates).

## Test plan

- [ ] Push a commit to a PR, then push a second commit; confirm the first run is cancelled.
- [ ] Touch only a `.md` file; confirm CI doesn't trigger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bwq1MezfGfcaaXQxAEZyNr)_