### PR TITLE
fix(auth): don't log users out on transient network failures

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -382,6 +382,42 @@ describe('api', () => {
     })
   })
 
+  describe('validateSessionDetailed', () => {
+    it("returns 'invalid' when no token", async () => {
+      expect(await api.validateSessionDetailed()).toBe('invalid')
+    })
+
+    it("returns 'valid' when server validates session", async () => {
+      localStorage.setItem('auth_token', 'tok')
+      vi.spyOn(global, 'fetch').mockResolvedValue(
+        jsonResponse({ success: true })
+      )
+      expect(await api.validateSessionDetailed()).toBe('valid')
+    })
+
+    it("returns 'invalid' on 401", async () => {
+      localStorage.setItem('auth_token', 'tok')
+      vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response('', { status: 401 })
+      )
+      expect(await api.validateSessionDetailed()).toBe('invalid')
+    })
+
+    it("returns 'unknown' on 5xx", async () => {
+      localStorage.setItem('auth_token', 'tok')
+      vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response('', { status: 503 })
+      )
+      expect(await api.validateSessionDetailed()).toBe('unknown')
+    })
+
+    it("returns 'unknown' when fetch throws (network error)", async () => {
+      localStorage.setItem('auth_token', 'tok')
+      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('boom'))
+      expect(await api.validateSessionDetailed()).toBe('unknown')
+    })
+  })
+
   describe('getCSRFToken', () => {
     it('returns token on successful response', async () => {
       vi.spyOn(global, 'fetch').mockResolvedValue(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -229,29 +229,52 @@ const api = {
     },
 
     async validateSession(): Promise<boolean> {
+        const result = await this.validateSessionDetailed();
+        // Preserve legacy behavior for callers that only want a boolean:
+        // both "invalid" and "unknown" map to false.
+        return result === 'valid';
+    },
+
+    // 'valid'   — server confirmed the session is good
+    // 'invalid' — server explicitly rejected the session (401/403)
+    // 'unknown' — could not determine (network failure, 5xx, etc.)
+    async validateSessionDetailed(): Promise<'valid' | 'invalid' | 'unknown'> {
         const token = getAuthToken();
         if (!token) {
-            return false;
+            return 'invalid';
         }
 
+        let response: Response;
         try {
-            const response = await fetch(`${getApiUrl()}/auth/session`, {
+            response = await fetch(`${getApiUrl()}/auth/session`, {
                 method: 'GET',
                 headers: {
                     'Authorization': `Bearer ${token}`,
                     'Content-Type': 'application/json',
                 },
             });
-
-            if (!response.ok) {
-                return false;
-            }
-
-            const data: AuthResponse = await response.json();
-            return data.success;
         } catch (error) {
-            console.error('Session validation failed:', error);
-            return false;
+            console.error('Session validation network error:', error);
+            return 'unknown';
+        }
+
+        if (response.status === 401 || response.status === 403) {
+            return 'invalid';
+        }
+
+        if (!response.ok) {
+            // 5xx or other non-auth errors — server is unhappy but the
+            // session itself hasn't been repudiated. Treat as unknown so
+            // the caller can retry instead of nuking the user's session.
+            return 'unknown';
+        }
+
+        try {
+            const data: AuthResponse = await response.json();
+            return data.success ? 'valid' : 'invalid';
+        } catch (error) {
+            console.error('Session validation parse error:', error);
+            return 'unknown';
         }
     },
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -10,6 +10,7 @@ vi.mock('./api', () => {
     changePassword: vi.fn(),
     verifyEmail: vi.fn(),
     validateSession: vi.fn(),
+    validateSessionDetailed: vi.fn(),
     getCSRFToken: vi.fn().mockResolvedValue('csrf'),
     refreshSession: vi.fn(),
     initiateOAuth: vi.fn(),
@@ -231,6 +232,96 @@ describe('AuthClient', () => {
       mockApi.validateSession.mockResolvedValue(true)
       expect(await auth.validateSession()).toBe(true)
       expect(mockApi.validateSession).toHaveBeenCalled()
+    })
+  })
+
+  describe('validateSessionDetailed', () => {
+    it("in mock mode, returns 'valid' when authenticated", async () => {
+      setMockHostname('localhost')
+      localStorage.setItem('auth_token', 'x')
+      expect(await auth.validateSessionDetailed()).toBe('valid')
+    })
+
+    it("in mock mode, returns 'invalid' when not authenticated", async () => {
+      setMockHostname('localhost')
+      expect(await auth.validateSessionDetailed()).toBe('invalid')
+    })
+
+    it('delegates to api in real mode and passes through unknown', async () => {
+      setMockHostname('example.com')
+      mockApi.validateSessionDetailed.mockResolvedValue('unknown')
+      expect(await auth.validateSessionDetailed()).toBe('unknown')
+      expect(mockApi.validateSessionDetailed).toHaveBeenCalled()
+    })
+  })
+
+  // Regression coverage for the original bug: tab visibility flips
+  // would call validateSession() and clear the local session on *any*
+  // failure, including transient network errors. The fix only clears on
+  // an authoritative 'invalid' from the server.
+  describe('visibility change behavior', () => {
+    beforeEach(() => {
+      setMockHostname('example.com')
+      // Seed an authenticated session that's nowhere near expiry so the
+      // post-validation refresh check is a no-op.
+      const oneDay = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+      localStorage.setItem('auth_token', 'tok')
+      localStorage.setItem('auth_session', JSON.stringify(makeSession(oneDay)))
+      // Pretend the tab is currently visible.
+      Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+    })
+
+    async function fireVisibilityAndDrain(timesToAdvanceMs: number[] = []) {
+      document.dispatchEvent(new Event('visibilitychange'))
+      // Let the chained promises / retry backoff resolve.
+      for (const ms of timesToAdvanceMs) {
+        await vi.advanceTimersByTimeAsync(ms)
+      }
+      await vi.runOnlyPendingTimersAsync()
+    }
+
+    it("keeps the session when validation is 'unknown' (transient network error)", async () => {
+      vi.useFakeTimers()
+      mockApi.validateSessionDetailed.mockResolvedValue('unknown')
+
+      await fireVisibilityAndDrain([500, 1000, 2000])
+
+      expect(localStorage.getItem('auth_token')).toBe('tok')
+      // Three retry attempts before giving up.
+      expect(mockApi.validateSessionDetailed).toHaveBeenCalledTimes(3)
+    })
+
+    it("clears the session on an authoritative 'invalid' response", async () => {
+      vi.useFakeTimers()
+      mockApi.validateSessionDetailed.mockResolvedValue('invalid')
+      const expired = vi.fn()
+      window.addEventListener('auth:session-expired', expired, { once: true })
+
+      await fireVisibilityAndDrain()
+
+      expect(localStorage.getItem('auth_token')).toBeNull()
+      expect(expired).toHaveBeenCalled()
+      // No retry once we have a definitive answer.
+      expect(mockApi.validateSessionDetailed).toHaveBeenCalledTimes(1)
+    })
+
+    it("stops retrying as soon as a definitive result arrives", async () => {
+      vi.useFakeTimers()
+      // Suppress the post-validation periodic check by marking validation as fresh.
+      localStorage.setItem('auth_last_validation', Date.now().toString())
+      mockApi.validateSessionDetailed
+        .mockResolvedValueOnce('unknown')
+        .mockResolvedValueOnce('valid')
+        .mockResolvedValueOnce('valid')
+
+      await fireVisibilityAndDrain([500, 1000])
+
+      expect(localStorage.getItem('auth_token')).toBe('tok')
+      expect(mockApi.validateSessionDetailed).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -74,19 +74,25 @@ class AuthClient {
 
     if (this.isAuthenticated()) {
       try {
-        const isValid = await this.validateSession();
-        if (!isValid) {
+        const result = await this.validateSessionDetailed();
+        if (result === 'invalid') {
           console.log('Session validation failed on initialization, clearing session');
           this.clearLocalSession();
           this.emitSessionExpired();
           return;
         }
-        console.log('Session validated successfully on initialization');
+        if (result === 'unknown') {
+          // Network/5xx on first load. Don't log the user out — the
+          // periodic monitor will revalidate once the network recovers.
+          console.log('Session validation inconclusive on initialization, keeping session');
+        } else {
+          console.log('Session validated successfully on initialization');
+        }
       } catch (error) {
+        // Defensive: validateSessionDetailed shouldn't throw, but if it
+        // does we still keep the session rather than logging the user
+        // out on a transient error.
         console.error('Session validation error on initialization:', error);
-        this.clearLocalSession();
-        this.emitSessionExpired();
-        return;
       }
 
       this.startSessionMonitoring();
@@ -158,12 +164,21 @@ class AuthClient {
     // session is still valid (long expiry, e.g. 24h) but the server
     // could have invalidated it. Validate with the server so the UI
     // doesn't sit on a stale token making API calls that 401.
-    this.validateSession()
-      .then(isValid => {
-        if (!isValid) {
+    //
+    // Only clear the local session on an *authoritative* invalid
+    // response from the server. Transient network failures or 5xx
+    // errors must not log the user out — that's the bug where users
+    // got booted when their connection blipped while switching tabs.
+    this.validateSessionWithRetry()
+      .then(result => {
+        if (result === 'invalid') {
           console.log('🔧 Visibility change: server says session invalid, clearing');
           this.clearLocalSession();
           this.emitSessionExpired();
+          return;
+        }
+        if (result === 'unknown') {
+          console.log('🔧 Visibility change: validation inconclusive, keeping session');
           return;
         }
         // Still valid — fall through to the normal refresh-if-near-expiry check.
@@ -172,6 +187,30 @@ class AuthClient {
       .catch(err => {
         console.error('🔧 Visibility change: validateSession threw', err);
       });
+  }
+
+  /**
+   * Validate the session with retry + exponential backoff. Returns the
+   * authoritative result from the server when it can, or 'unknown' if
+   * every attempt failed for non-auth reasons (network/5xx). Callers
+   * should NOT treat 'unknown' as a logout signal.
+   */
+  private async validateSessionWithRetry(
+    attempts: number = 3,
+    initialDelayMs: number = 500,
+  ): Promise<'valid' | 'invalid' | 'unknown'> {
+    let delay = initialDelayMs;
+    for (let i = 0; i < attempts; i++) {
+      const result = await this.validateSessionDetailed();
+      if (result !== 'unknown') {
+        return result;
+      }
+      if (i < attempts - 1) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay *= 2;
+      }
+    }
+    return 'unknown';
   }
 
   /**
@@ -273,14 +312,17 @@ class AuthClient {
       
       if (!lastValidation || (now - parseInt(lastValidation)) > validationInterval) {
         console.log('🔧 Session check: Performing periodic session validation');
-        const isValid = await this.validateSession();
-        if (isValid) {
+        const result = await this.validateSessionWithRetry();
+        if (result === 'valid') {
           localStorage.setItem('auth_last_validation', now.toString());
           console.log('🔧 Session check: Periodic validation successful');
-        } else {
-          console.log('🔧 Session check: Periodic validation failed, clearing local state');
+        } else if (result === 'invalid') {
+          console.log('🔧 Session check: Periodic validation rejected by server, clearing local state');
           this.clearLocalSession();
           this.emitSessionExpired();
+        } else {
+          // 'unknown' — network/5xx. Keep the session and try again on the next tick.
+          console.log('🔧 Session check: Periodic validation inconclusive, will retry next interval');
         }
       } else {
         console.log('🔧 Session check: Session still valid, skipping validation');
@@ -578,6 +620,18 @@ class AuthClient {
     }
 
     return await api.validateSession();
+  }
+
+  /**
+   * Validate current session with server, distinguishing between an
+   * authoritative invalid response and a transient/unknown failure.
+   */
+  async validateSessionDetailed(): Promise<'valid' | 'invalid' | 'unknown'> {
+    if (this.shouldUseMock()) {
+      return this.isAuthenticated() ? 'valid' : 'invalid';
+    }
+
+    return await api.validateSessionDetailed();
   }
 
   /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -74,7 +74,7 @@ class AuthClient {
 
     if (this.isAuthenticated()) {
       try {
-        const result = await this.validateSessionDetailed();
+        const result = await this.validateSessionWithRetry();
         if (result === 'invalid') {
           console.log('Session validation failed on initialization, clearing session');
           this.clearLocalSession();


### PR DESCRIPTION
## Summary
- Users reported being unexpectedly logged out of Kinetiq Trainer while using it, especially around tab switches.
- Root cause: the `visibilitychange` handler in `src/lib/auth.ts` revalidates the session every time the tab regains focus, and `api.validateSession()` collapsed every non-OK response (including network errors and 5xx) to `false`. A brief connection blip → instant `clearLocalSession()` + `emitSessionExpired()`, even though the token was still valid server-side.
- Fix: add `validateSessionDetailed()` returning `'valid' | 'invalid' | 'unknown'`. Only treat 401/403 as authoritative invalidations; treat network errors and 5xx as `'unknown'` and keep the session. The visibility handler and the periodic-validation tick now retry with exponential backoff and only log the user out on a real rejection. The on-init validation path got the same tolerance.

## Test plan
- [x] `npm test` — 272/272 pass, including new `validateSessionDetailed` cases (`returns 'unknown' on 5xx`, `returns 'unknown' when fetch throws`, `returns 'invalid' on 401`).
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: log into Kinetiq Trainer, switch tabs for a few minutes with the network throttled / briefly offline, return — session should persist.
- [ ] Manual: invalidate the session server-side, switch tabs back — user should still be logged out promptly (≤ a couple of retry cycles).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhNEEajJ6a8jvCyXxqs9nL)_