### PR TITLE
Read reset/verify tokens from URL instead of hardcoded placeholders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { CheckCircle, XCircle, AlertTriangle } from "lucide-react"
@@ -22,6 +22,18 @@ function App() {
   const [isMockMode, setIsMockMode] = useState(false)
 
   const { user, logout, isLoading } = useAuth()
+
+  // Read reset / verify tokens from the URL (#7 MED-5). Distinct param
+  // names so they don't collide with the OAuth callback's ?token=
+  // detection above.
+  const resetToken = useMemo(
+    () => new URLSearchParams(window.location.search).get("reset_token") ?? undefined,
+    [],
+  )
+  const verifyToken = useMemo(
+    () => new URLSearchParams(window.location.search).get("verify_token") ?? undefined,
+    [],
+  )
 
   // Check for OAuth callback
   useEffect(() => {
@@ -173,7 +185,7 @@ function App() {
                   }}
                   onError={handleError}
                   onSwitchToLogin={() => setView("login")}
-                  token={"your-reset-token-here"}
+                  token={resetToken}
                 />
               </CardContent>
             </Card>
@@ -260,7 +272,7 @@ function App() {
             }}
             onError={handleError}
             onSwitchToLogin={() => handleViewChange("login")}
-            token={"your-verification-token-here"}
+            token={verifyToken}
           />
         )}
         {view === "authCallback" && (

--- a/src/components/AuthDemo.tsx
+++ b/src/components/AuthDemo.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { CheckCircle, XCircle, AlertTriangle, Clock, Shield, ShieldOff, LogOut } from "lucide-react"
@@ -26,6 +26,18 @@ export default function AuthDemo() {
   const [timeUntilExpiration, setTimeUntilExpiration] = useState<string>("")
   const [isSessionExpiringSoon, setIsSessionExpiringSoon] = useState(false)
   const [isSignedIn, setIsSignedIn] = useState(false)
+
+  // Read reset / verify tokens from the URL (#7 MED-5). Distinct param
+  // names so they don't collide with the OAuth callback's ?token= flow.
+  // No param → undefined → form's "token is required" error surfaces.
+  const resetToken = useMemo(
+    () => new URLSearchParams(window.location.search).get("reset_token") ?? undefined,
+    [],
+  )
+  const verifyToken = useMemo(
+    () => new URLSearchParams(window.location.search).get("verify_token") ?? undefined,
+    [],
+  )
 
   const { user, logout, isLoading } = useAuth()
 
@@ -296,8 +308,7 @@ export default function AuthDemo() {
             }}
             onError={handleError}
             onSwitchToLogin={() => handleViewChange("login")}
-            // TODO: Pass the token from the URL or other source
-            token={"your-reset-token-here"} 
+            token={resetToken}
           />
         )}
         {view === "verifyEmail" && (
@@ -308,8 +319,7 @@ export default function AuthDemo() {
             }}
             onError={handleError}
             onSwitchToLogin={() => handleViewChange("login")}
-            // TODO: Pass the token from the URL or other source
-            token={"your-verification-token-here"} 
+            token={verifyToken}
           />
         )}
         {view === "accountSettings" && (


### PR DESCRIPTION
Addresses #7 MED-5.

## Problem

`AuthDemo.tsx` and `App.tsx` both pass literal strings into the auth forms:

```tsx
<ChangePasswordForm token={"your-reset-token-here"} />
<EmailVerificationForm token={"your-verification-token-here"} />
```

Both strings are truthy, so the `if (!token) { setError(...) }` guards inside the forms never fire. The forms end up calling `auth.changePassword("your-reset-token-here", newPassword)` and `auth.verifyEmail("your-verification-token-here")` against the real auth service. If the server does only structural validation, the placeholder may actually be accepted.

## Change

Both files now read tokens from the URL:

```tsx
const resetToken = useMemo(
  () => new URLSearchParams(window.location.search).get("reset_token") ?? undefined,
  [],
)
const verifyToken = useMemo(
  () => new URLSearchParams(window.location.search).get("verify_token") ?? undefined,
  [],
)
```

…and pass `resetToken` / `verifyToken` into the forms. When the param isn't present, `undefined` flows through and the forms' existing "Reset token is required" / equivalent error path surfaces — the truthful state for a demo without a real reset URL.

### Param-name choice

Distinct names (`reset_token`, `verify_token`) avoid collision with the OAuth callback's existing `?token=` detection in `App.tsx`:

```tsx
if (params.has('token')) {
  setView('authCallback');
}
```

If we used `token` for resets too, hitting `/?token=foo` would route to the OAuth callback even when the intent was a password reset.

## Test plan

- [ ] Visit the demo with no params → dev-buttons → Change Password → submit. Expect "Reset token is required" (was: silently submitting the placeholder).
- [ ] Visit `/?reset_token=abc123` → Change Password → submit → form posts `abc123`.
- [ ] Visit `/?token=oauth_xyz` → still routes to AuthCallback (OAuth flow unchanged).
- [ ] Existing unit tests pass (forms unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGc2oKMEry15PVQMjfufrz)_