### PR TITLE
Gate redirectUrl through same-origin check in Login + Registration

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Eye, EyeOff, Loader2 } from "lucide-react"
 import { auth } from "@/lib/auth"
+import { isSafeRedirect } from "@/lib/utils"
 import type { User } from "@/lib/types"
 import OAuthButtons from "./OAuthButtons"
 
@@ -62,12 +63,17 @@ export default function LoginForm({ onSuccess, onError, redirectUrl, onSwitchToR
       const user = await auth.login({ email, password }, staySignedIn)
       console.log("Login successful:", user)
       onSuccess?.(user)
-      
-      // Redirect after a short delay
+
+      // Same-origin gate (#7 HIGH-1) — anything off-origin is dropped
+      // silently rather than handing a phisher a live session.
       if (redirectUrl) {
-        setTimeout(() => {
-          window.location.href = redirectUrl
-        }, 1000)
+        if (isSafeRedirect(redirectUrl)) {
+          setTimeout(() => {
+            window.location.href = redirectUrl
+          }, 1000)
+        } else if (import.meta.env.DEV) {
+          console.warn(`[auth-components] Ignoring cross-origin redirectUrl: ${redirectUrl}`)
+        }
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Login failed"

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -11,7 +11,7 @@ import { Eye, EyeOff, Loader2 } from "lucide-react"
 import { Checkbox } from "@/components/ui/checkbox"
 import { auth } from "@/lib/auth"
 import type { User } from "@/lib/types"
-import { validatePassword } from "@/lib/utils"
+import { isSafeRedirect, validatePassword } from "@/lib/utils"
 import { PasswordStrengthIndicator } from "./ui/password-strength-indicator"
 import OAuthButtons from "./OAuthButtons"
 
@@ -57,12 +57,17 @@ export default function RegistrationForm({ onSuccess, onError, redirectUrl, onSw
       const user = await auth.signup({ firstName, lastName, email, password })
       console.log("Registration successful:", user)
       onSuccess?.(user)
-      
-      // Redirect after a short delay
+
+      // Same-origin gate (#7 HIGH-1) — anything off-origin is dropped
+      // silently rather than handing a phisher a live session.
       if (redirectUrl) {
-        setTimeout(() => {
-          window.location.href = redirectUrl
-        }, 1000)
+        if (isSafeRedirect(redirectUrl)) {
+          setTimeout(() => {
+            window.location.href = redirectUrl
+          }, 1000)
+        } else if (import.meta.env.DEV) {
+          console.warn(`[auth-components] Ignoring cross-origin redirectUrl: ${redirectUrl}`)
+        }
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Registration failed"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -196,3 +196,22 @@ export function isPasswordMinimallyValid(password: string): boolean {
   
   return complexityCount >= 2;
 }
+
+/**
+ * Returns true if `redirectUrl` resolves to the same origin as the
+ * current page. Relative URLs ("/dashboard") and same-origin absolute
+ * URLs are accepted; cross-origin absolute URLs and malformed inputs
+ * are rejected.
+ *
+ * Used to gate post-login / post-register redirects against open-
+ * redirect phishing — see #7 HIGH-1.
+ */
+export function isSafeRedirect(redirectUrl: string | null | undefined): boolean {
+  if (!redirectUrl) return false;
+  try {
+    const parsed = new URL(redirectUrl, window.location.origin);
+    return parsed.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Addresses #7 HIGH-1.

## Problem

Both `LoginForm` and `RegistrationForm` accepted a `redirectUrl` prop and did

```ts
window.location.href = redirectUrl
```

with **no validation**. A consumer app that passes an unsanitised `redirectUrl` (e.g. from a `?redirect=` query string, or some shared session storage) hands a phisher this attack:

1. Phisher sends a victim `https://app.example.com/login?redirect=https://app.example.com.evil.io/dashboard`.
2. User logs in correctly on `app.example.com`.
3. App writes a real session, then redirects the now-authenticated browser to `evil.io`'s look-alike. Cookies/tokens for `evil.io` arrive set.

## Change

New helper `isSafeRedirect(redirectUrl)` in `src/lib/utils.ts`:

```ts
export function isSafeRedirect(redirectUrl: string | null | undefined): boolean {
  if (!redirectUrl) return false
  try {
    const parsed = new URL(redirectUrl, window.location.origin)
    return parsed.origin === window.location.origin
  } catch {
    return false
  }
}
```

Both forms now route their redirect through it:

```ts
if (redirectUrl) {
  if (isSafeRedirect(redirectUrl)) {
    setTimeout(() => { window.location.href = redirectUrl }, 1000)
  } else if (import.meta.env.DEV) {
    console.warn(`[auth-components] Ignoring cross-origin redirectUrl: ${redirectUrl}`)
  }
}
```

- Relative URLs (`"/dashboard"`) still work — they resolve against `window.location.origin`.
- Same-origin absolute URLs work.
- Cross-origin URLs are silently dropped, with a dev-only `console.warn` to surface misuse during development.

## Interaction with #14

This branch is independent of #14. `src/lib/utils.ts` here keeps the original `isPasswordMinimallyValid` body — once #14 merges and softens it to a length floor, git will three-way-merge the two changes cleanly (one touches the function body, the other appends a new function).

## Test plan

- [ ] Login with `redirectUrl="/dashboard"` → still redirects.
- [ ] Login with `redirectUrl="https://{same-origin}/dashboard"` → still redirects.
- [ ] Login with `redirectUrl="https://evil.example/login"` → no redirect; dev console shows the warning.
- [ ] Login with `redirectUrl=""` / `undefined` → no redirect (unchanged behaviour).
- [ ] Same matrix for Registration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGc2oKMEry15PVQMjfufrz)_