### PR TITLE
Disable sourcemaps in library build output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,11 @@ export default defineConfig({
         }
       }
     },
-    sourcemap: true,
+    // Source maps are not shipped (#7 LOW-2). Published .js.map files
+    // embed the full TypeScript source, which adds disclosure on top
+    // of debuggability for consumers — and consumers can already read
+    // src/ directly from the repo if they need it.
+    sourcemap: false,
     minify: false
   },
   resolve: {


### PR DESCRIPTION
Addresses #7 LOW-2.

## Problem

`vite.config.ts` had `sourcemap: true`. Every published `.js.map` embeds the full original TypeScript — internal helper names, mock-token literals, endpoint path strings, error message templates. For a published auth library this is incremental disclosure beyond what npm-publishing the compiled bundle already exposes.

## Change

```diff
-    sourcemap: true,
+    sourcemap: false,
```

## Tradeoff

Source maps make consumer-side debugging slightly nicer (stack frames point at original .tsx lines). Against that: consumers can already read `src/` directly from this repo when they need to dig in, and the published surface is small enough that minified-stack debugging is tractable.

If consumer debuggability becomes a pain, the alternative is shipping source maps only to a private symbol server — but for now, off is the simpler default.

## Test plan

- [ ] `npm run build` → confirm no `.js.map` files appear in `dist/`.
- [ ] Confirm `dist/*.mjs` / `dist/*.cjs` are still produced.
- [ ] Existing tests still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGc2oKMEry15PVQMjfufrz)_