### PR TITLE
Remove the document.body.textContent JSON-parse fallback in AuthCallback

### DIFF
--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -11,13 +11,6 @@ interface AuthCallbackProps {
   onError: (error: string) => void;
 }
 
-interface OAuthResponse {
-  success: boolean;
-  message: string;
-  user: User;
-  session: Session;
-}
-
 export default function AuthCallback({}: AuthCallbackProps) {
   const [isProcessing, setIsProcessing] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -30,7 +23,13 @@ export default function AuthCallback({}: AuthCallbackProps) {
         setError(null);
         setSuccess(false);
 
-        // Method 1: Try to get data from URL parameters (fallback)
+        // Read session data from URL parameters. This path is itself
+        // unsafe (see #7 CRIT-2 — unsigned URL params are not
+        // authentication), and is being migrated to a server-side
+        // code-exchange flow in a follow-up paired with deployments
+        // #168 C-2. CRIT-5 removed the dangerous secondary path
+        // (parsing document.body.textContent as JSON), so this is the
+        // only branch now.
         const params = new URLSearchParams(window.location.search);
         const token = params.get('token');
         const userId = params.get('userId');
@@ -40,7 +39,6 @@ export default function AuthCallback({}: AuthCallbackProps) {
         const createdAt = params.get('createdAt');
 
         if (token && userId && email && firstName && lastName && createdAt) {
-          // Handle URL parameter-based callback
           const user: User = {
             id: userId,
             email,
@@ -69,45 +67,6 @@ export default function AuthCallback({}: AuthCallbackProps) {
             window.location.href = '/';
           }, 1500);
           return;
-        }
-
-        // Method 2: Try to parse JSON response from page content
-        const responseText = document.body.textContent || '';
-        
-        if (responseText.trim()) {
-          try {
-            const oauthResponse: OAuthResponse = JSON.parse(responseText);
-            
-            // Validate the response structure
-            if (!oauthResponse.success) {
-              throw new Error(oauthResponse.message || 'OAuth authentication failed');
-            }
-
-            if (!oauthResponse.user || !oauthResponse.session) {
-              throw new Error('Incomplete authentication response - missing user or session data');
-            }
-
-            // Store the session data securely
-            const { user, session } = oauthResponse;
-            
-            localStorage.setItem('auth_token', session.token);
-            localStorage.setItem('auth_user', JSON.stringify(user));
-            localStorage.setItem('auth_session', JSON.stringify(session));
-            localStorage.setItem('auth_stay_signed_in', 'true');
-
-            // Clear the page content
-            document.body.innerHTML = '';
-            
-            setSuccess(true);
-            setTimeout(() => {
-              window.location.href = '/';
-            }, 1500);
-            return;
-
-          } catch (parseError) {
-            console.error('Failed to parse OAuth response:', parseError);
-            // Continue to error handling
-          }
         }
 
         // If we get here, no valid data was found


### PR DESCRIPTION
Addresses #7 **CRIT-5**.

## Problem

`AuthCallback.tsx` had a "Method 2" fallback that:

```ts
const responseText = document.body.textContent || '';
if (responseText.trim()) {
  const oauthResponse: OAuthResponse = JSON.parse(responseText);
  ...
  localStorage.setItem('auth_token', session.token);
  ...
  document.body.innerHTML = '';   // destroys page DOM from untrusted content
```

A network-level attacker (MITM on HTTP, compromised CDN edge, captive portal) who can inject a JSON-shaped body into the OAuth callback page response causes this component to:

1. Parse the body as an authenticated session.
2. Store the attacker's tokens in `localStorage`.
3. Wipe the page DOM with `innerHTML = ''`.

No part of this codepath is gated on anything — any string the browser happens to render that parses as the right JSON shape becomes a valid session.

## Change

Removes Method 2 entirely, plus its dead `OAuthResponse` interface. Method 1 (URL parameters) is unchanged — that path is also unsafe (this is **CRIT-2**) and is being migrated to a server-side code-exchange flow in a follow-up PR paired with **deployments #168 C-2**. That follow-up is the right place to redesign the callback; this PR removes the most acute and most-isolated of the four critical findings.

After this change, an OAuth callback hit without any URL params fails with the existing "No valid authentication data found" error — the truthful state.

## Why ship CRIT-5 separately

The four open Criticals in #7 are interconnected:

| ID | What | Scope |
|---|---|---|
| CRIT-1 | localStorage session storage | Architectural — needs HttpOnly cookies, paired server change |
| CRIT-2 | OAuth callback trusts URL params | Architectural — paired with deployments #168 C-2 |
| CRIT-5 | Body-text JSON parse fallback | **Standalone — surgical delete** |
| (deployments C-2) | OAuth token in URL | Architectural pair to CRIT-2 |

CRIT-5 is the only one that fits in a 25-line delete with no cross-repo coordination. Shipping it now removes one attack vector immediately.

## Test plan

- [ ] Existing OAuth callback flow with URL params still works (Method 1 unchanged).
- [ ] Visit `/auth/callback` without URL params → "Authentication Failed: No valid authentication data found" (previously this might have succeeded against attacker-controlled body content).
- [ ] No `document.body.innerHTML = ''` anywhere in the file.
- [ ] No `JSON.parse(document.body...)` anywhere in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGc2oKMEry15PVQMjfufrz)_