### PR TITLE
Audit: fail-safe revalidation, OAuth param encoding, email-format validation

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Eye, EyeOff, Loader2 } from "lucide-react"
 import { auth } from "@/lib/auth"
-import { isSafeRedirect } from "@/lib/utils"
+import { isSafeRedirect, isValidEmail } from "@/lib/utils"
 import type { User } from "@/lib/types"
 import OAuthButtons from "./OAuthButtons"
 
@@ -36,6 +36,11 @@ export default function LoginForm({ onSuccess, onError, redirectUrl, onSwitchToR
     
     if (!email || !password) {
       setError("Please fill in all fields")
+      return
+    }
+
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email address")
       return
     }
 
@@ -89,6 +94,11 @@ export default function LoginForm({ onSuccess, onError, redirectUrl, onSwitchToR
     
     if (!email) {
       setError("Please enter your email address")
+      return
+    }
+
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email address")
       return
     }
 

--- a/src/components/PasswordResetForm.tsx
+++ b/src/components/PasswordResetForm.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Loader2 } from "lucide-react"
 import { auth } from "@/lib/auth"
+import { isValidEmail } from "@/lib/utils"
 
 interface PasswordResetFormProps {
   onSuccess?: () => void
@@ -26,6 +27,11 @@ export default function PasswordResetForm({ onSuccess, onError, onSwitchToLogin 
     
     if (!email) {
       setError("Please enter your email address")
+      return
+    }
+
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email address")
       return
     }
 

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -11,7 +11,7 @@ import { Eye, EyeOff, Loader2 } from "lucide-react"
 import { Checkbox } from "@/components/ui/checkbox"
 import { auth } from "@/lib/auth"
 import type { User } from "@/lib/types"
-import { isPasswordMinimallyValid, isSafeRedirect, validatePassword } from "@/lib/utils"
+import { isPasswordMinimallyValid, isSafeRedirect, isValidEmail, validatePassword } from "@/lib/utils"
 import { PasswordStrengthIndicator } from "./ui/password-strength-indicator"
 import OAuthButtons from "./OAuthButtons"
 
@@ -49,6 +49,11 @@ export default function RegistrationForm({ onSuccess, onError, redirectUrl, onSw
     
     if (!firstName || !lastName || !email || !password) {
       setError("Please fill in all fields")
+      return
+    }
+
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email address")
       return
     }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -340,7 +340,15 @@ const api = {
     },
 
     async initiateOAuth(provider: string, staySignedIn: boolean = true, frontendRedirectUrl: string): Promise<{ url: string }> {
-        const response = await fetch(`${getApiUrl()}/auth/oauth/initiate?provider=${provider}&staySignedIn=${staySignedIn}&frontendRedirectUrl=${encodeURIComponent(frontendRedirectUrl)}`, {
+        // Build the query with URLSearchParams so every value is encoded.
+        // Interpolating `provider` raw let a value like "google&foo=bar"
+        // inject extra query params into the initiate request.
+        const params = new URLSearchParams({
+            provider,
+            staySignedIn: String(staySignedIn),
+            frontendRedirectUrl,
+        });
+        const response = await fetch(`${getApiUrl()}/auth/oauth/initiate?${params.toString()}`, {
             method: 'GET',
             headers: {
                 'Accept': 'application/json',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -306,11 +306,18 @@ class AuthClient {
     } else {
       // Session is still valid, but let's validate it with the server periodically
       // Only validate every 5 minutes to avoid too many requests
-      const lastValidation = localStorage.getItem('auth_last_validation');
+      const lastValidation = parseInt(
+        localStorage.getItem('auth_last_validation') ?? '',
+        10,
+      );
       const now = Date.now();
       const validationInterval = 5 * 60 * 1000; // 5 minutes
-      
-      if (!lastValidation || (now - parseInt(lastValidation)) > validationInterval) {
+
+      // NaN when the key is missing or corrupted — fail safe by validating.
+      // (`NaN > interval` is false, which would otherwise skip validation
+      // indefinitely, leaving a corrupted timestamp wedging out all future
+      // server revalidation.)
+      if (Number.isNaN(lastValidation) || (now - lastValidation) > validationInterval) {
         if (import.meta.env.DEV) { console.log('🔧 Session check: Performing periodic session validation'); }
         const result = await this.validateSessionWithRetry();
         if (result === 'valid') {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   validatePassword,
   isPasswordValid,
   isPasswordMinimallyValid,
+  isValidEmail,
 } from './utils'
 
 describe('cn', () => {
@@ -226,5 +227,24 @@ describe('isPasswordMinimallyValid', () => {
     expect(isPasswordMinimallyValid('abcdefg!')).toBe(true) // lower + special
     expect(isPasswordMinimallyValid('12345!@#')).toBe(true) // numbers + special
     expect(isPasswordMinimallyValid('Ab1!xxxx')).toBe(true) // all 4
+  })
+})
+
+describe('isValidEmail', () => {
+  it('accepts well-formed addresses', () => {
+    expect(isValidEmail('a@b.com')).toBe(true)
+    expect(isValidEmail('first.last@sub.example.co')).toBe(true)
+    expect(isValidEmail('  trimmed@example.com  ')).toBe(true)
+  })
+
+  it('rejects malformed or empty input', () => {
+    expect(isValidEmail('')).toBe(false)
+    expect(isValidEmail(null)).toBe(false)
+    expect(isValidEmail(undefined)).toBe(false)
+    expect(isValidEmail('no-at-sign')).toBe(false)
+    expect(isValidEmail('missing@domain')).toBe(false)
+    expect(isValidEmail('@no-local.com')).toBe(false)
+    expect(isValidEmail('spaces in@email.com')).toBe(false)
+    expect(isValidEmail('two@@at.com')).toBe(false)
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -213,3 +213,14 @@ export function isSafeRedirect(redirectUrl: string | null | undefined): boolean 
     return false;
   }
 }
+
+/**
+ * Pragmatic client-side email format check: a non-empty local part, an `@`,
+ * and a dotted domain, with no whitespace. Deliberately permissive (the
+ * server is the source of truth) — its job is to catch obvious typos before
+ * a pointless network round-trip, not to fully implement RFC 5322.
+ */
+export function isValidEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}


### PR DESCRIPTION
## Summary

A batch of audit fixes for the auth components.

### 1. Periodic revalidation can wedge on a corrupted timestamp (`src/lib/auth.ts`)
The 5-minute "validate with the server" check read `auth_last_validation` and gated on `!lastValidation || (now - parseInt(lastValidation)) > interval`. A non-numeric stored value parses to `NaN`, and `now - NaN > interval` is `false` — while `!lastValidation` is also false for a non-empty string — so periodic server revalidation was **skipped indefinitely**. Now parsed once (with a radix) and `NaN` is treated as "validate now" (fail safe).

### 2. OAuth initiate query params not encoded (`src/lib/api.ts`)
`api.initiateOAuth` interpolated `provider`/`staySignedIn` raw into the URL (only `frontendRedirectUrl` was encoded). Since `provider` is typed `string`, a value like `google&foo=bar` could inject extra query params. Now built with `URLSearchParams`.

### 3. Client-side email-format validation (`LoginForm`, `RegistrationForm`, `PasswordResetForm`)
The forms only checked that email was non-empty, so a malformed address made a pointless round-trip and a vaguer server error. Added a permissive `isValidEmail()` helper (server stays source of truth) and gated all four email submit paths on it.

## Verification
- `tsc --noEmit` clean.
- Full vitest suite: **275 passing** (added `isValidEmail` unit tests).

## Out of scope (considered, intentionally not changed)
- `window.location.href = url` after `api.initiateOAuth` is **not** `isSafeRedirect`-gated — that URL is the OAuth provider's authorize endpoint (off-origin by design).
- Per-request CSRF fetch in `makeAuthenticatedRequest` left as-is (caching could break a single-use CSRF model).

🤖 Generated with [Claude Code](https://claude.ai/code)